### PR TITLE
Adding optional defensive programming tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# definition-interop compiler's test suite
+# definition-interop container's test suite
 
 Modules (aka packages or bundles) are widespread in modern frameworks. Unfortunately each framework has its own convention and tools for writing them. The goal of *container-interop* and more specifically *definition-interop* is to help developers write modules that can work in any framework.
 
 *definition-interop* contains interfaces helping developers describe container definitions (objects that can be cast to a container entry).
 
-This package contains a set of test suites that can be used to ensure that a container/compiler is indeed compatible with definition-interop.
+This package contains a set of test suites that can be used to ensure that a container/compiler is indeed compatible with *definition-interop*.
 
 ## How does it work?
 
@@ -15,5 +15,7 @@ Container / compilers compatible with *container-interop* should be able to pass
 ## Usage
 
 This package contains a `AbstractDefinitionCompatibilityTest` class. This is an abstract PHPUnit test class.
-In your package, you should extend this class and implement the `compileDefinitions` method. This method should return a container-interop compatible container.
+In your package, you should extend this class and implement 2 abstract methods:
 
+- `compileDefinitions` method: This method should return a container-interop compatible container.
+- `shouldRunDefensiveProgrammingTests` method: This method should return `true` or `false`. Return true if you want to test your container against defensive programming best practices. If you enable this, tests will provide invalid data to your container and it is expected that your container will throw an exception. Defensive programming tests are out-of-scope of *definition-interop* so they are not compulsory, only recommended.

--- a/src/AbstractDefinitionCompatibilityTest.php
+++ b/src/AbstractDefinitionCompatibilityTest.php
@@ -19,6 +19,14 @@ abstract class AbstractDefinitionCompatibilityTest extends \PHPUnit_Framework_Te
      */
     abstract protected function getContainer(DefinitionProviderInterface $definitionProvider);
 
+    /**
+     * Returns true if the tested container should be tested against defensive programming tests.
+     * Returns false if the tested container should not be tested against defensive programming tests.
+     *
+     * @return boolean
+     */
+    abstract protected function shouldRunDefensiveProgrammingTests();
+
     public function testInstance()
     {
         $referenceDefinition = new \Assembly\ObjectDefinition('\\stdClass');
@@ -41,6 +49,7 @@ abstract class AbstractDefinitionCompatibilityTest extends \PHPUnit_Framework_Te
     }
 
     /**
+     * Defensive programming test.
      * Invalid objects (objects not extending one of the xxxDefinitionInterface interfaces) should trigger
      * an exception.
      *
@@ -48,6 +57,10 @@ abstract class AbstractDefinitionCompatibilityTest extends \PHPUnit_Framework_Te
      */
     public function testParameterException()
     {
+        if (!$this->shouldRunDefensiveProgrammingTests()) {
+            throw new \Exception();
+        }
+
         $assemblyDefinition = new \Assembly\ObjectDefinition('Interop\Container\Definition\Test\Fixtures\\Test');
         $assemblyDefinition->addConstructorArgument(new \stdClass());
 
@@ -121,10 +134,16 @@ abstract class AbstractDefinitionCompatibilityTest extends \PHPUnit_Framework_Te
     }
 
     /**
+     * Defensive programming test.
+     *
      * @expectedException \Exception
      */
     public function testUnsupportedDefinition()
     {
+        if (!$this->shouldRunDefensiveProgrammingTests()) {
+            throw new \Exception();
+        }
+
         $definition = new UnsupportedDefinition();
 
         $container = $this->getContainer(new ArrayDefinitionProvider([


### PR DESCRIPTION
Rather than removing the tests related to defensive programming techniques in #2, I'd propose to make all defensive programming related tests optional.

I added an additional abstract method: "shouldRunDefensiveProgrammingTests". If it returns true, defensive programming tests are run, otherwise, they are skipped.

It enables us to keep the tests that are valuable, and not to make them compulsory at the same time.

Also, I chose not to put the "defensive programming" tests in a separate test class because 2 abstract test classes means 2 concrete classes implementing twice the same `getContainer` method (or you have to play with traits to avoid repeatin the `getContainer` method which is not completely straightforward).
