### PR TITLE
Updating testParametersContainingSubDefinitions

### DIFF
--- a/src/AbstractDefinitionCompatibilityTest.php
+++ b/src/AbstractDefinitionCompatibilityTest.php
@@ -164,7 +164,6 @@ abstract class AbstractDefinitionCompatibilityTest extends \PHPUnit_Framework_Te
     public function testParametersContainingSubDefinitions()
     {
         $container = $this->getContainer(new ArrayDefinitionProvider([
-            'foo' => 'bar',
             'parameter' => new ParameterDefinition([
                 'abc' => new Reference('foo'),
             ]),


### PR DESCRIPTION
I removed the `"foo"=>"bar"` part of the definitions array.
A DefinitionProvider should return an array of `DefinitionInterface`, indexed by key. `"bar"` is not a valid `DefinitionInterface`.

Note: the `ArrayDefinitionProvider` used in this test is NOT the one from Assembly (that wraps values not implementing the `DefinitionInterface` into `ParameterDefinition` objects). It is one I wrote for the tests that does pass the array "as is".
